### PR TITLE
Send sistEndret i body på api-kall

### DIFF
--- a/src/services/rest-service.ts
+++ b/src/services/rest-service.ts
@@ -189,11 +189,16 @@ export const useHentRefusjon = (refusjonId?: string, sistEndret?: string): Refus
 };
 
 export const oppdaterRefusjonFetcher = async (key: string, { arg }: { arg: string }) => {
-    await api.post(`${key}/sett-kontonummer-og-inntekter`, null, {
-        headers: {
-            'If-Unmodified-Since': arg,
-        },
-    });
+    await api.post(
+        `${key}/sett-kontonummer-og-inntekter`,
+        // TODO: Fjern body
+        { sistEndret: arg },
+        {
+            headers: {
+                'If-Unmodified-Since': arg,
+            },
+        }
+    );
 };
 
 export const useHentTidligereRefusjoner = (refusjonId: string): Refusjon[] => {


### PR DESCRIPTION
For å avdekke om det er problematisk oppførsel
fra headere for noen brukere, sender vi også sistEndret i request-kroppen til "sett-kontonummer-og-inntekter".

Dette er en midlertidig endring som vil fjernes senere